### PR TITLE
acu76466 - Non-delivery response in Sender when send fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_agent (0.10.12)
+    right_agent (0.10.13)
       eventmachine (~> 0.12.10)
       json (~> 1.4)
       msgpack (= 0.4.4)

--- a/right_agent.gemspec
+++ b/right_agent.gemspec
@@ -24,8 +24,8 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_agent'
-  spec.version   = '0.10.12'
-  spec.date      = '2012-08-27'
+  spec.version   = '0.10.13'
+  spec.date      = '2013-02-07'
   spec.authors   = ['Lee Kirchhoff', 'Raphael Simon', 'Tony Spataro']
   spec.email     = 'lee@rightscale.com'
   spec.homepage  = 'https://github.com/rightscale/right_agent'


### PR DESCRIPTION
@ryanwilliamson This is a fix for #14974. I stepped to 0.10.13 and will publish this gem once it gets merged to v0.10. I will then tag it as 0.10.13 per recommendation from Tony and create the 5.8.8 patch that steps the Gemfile.
