### PR TITLE
acu93479 - Change agent to route response to request.reply_to so that ma...

### DIFF
--- a/lib/right_agent/agent.rb
+++ b/lib/right_agent/agent.rb
@@ -721,7 +721,7 @@ module RightScale
     def dispatch_request(request, queue)
       begin
         if result = @dispatcher.dispatch(request)
-          exchange = {:type => :queue, :name => "response", :options => {:durable => true, :no_declare => @options[:secure]}}
+          exchange = {:type => :queue, :name => request.reply_to, :options => {:durable => true, :no_declare => @options[:secure]}}
           @broker.publish(exchange, result, :persistent => true, :mandatory => true, :log_filter => [:tries, :persistent, :duration])
         end
       rescue Dispatcher::DuplicateRequest

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -426,9 +426,9 @@ describe RightScale::Agent do
         end
       end
 
-      it "should publish result from dispatched request to response queue" do
+      it "should publish result from dispatched request to request reply_to" do
         run_in_em do
-          request = RightScale::Request.new("/foo/bar", "payload")
+          request = RightScale::Request.new("/foo/bar", "payload", {:reply_to => "response"})
           @broker.should_receive(:subscribe).with(hsh(:name => @identity), nil, Hash, Proc).
                                              and_return(@broker_ids).and_yield(@broker_id, request, @header).once
           result = flexmock("result")


### PR DESCRIPTION
...pper in control
@ryanwilliamson @tony-spataro-rs 
This change puts control back into the mapper for where an agent sends its responses. This  will help reduce the number of message hops when the router (aka broker proxy is introduced). I verified this works by rebooting a 5.8 instance after inserting these modifications. I would like to get this change into 5.9.

BTW, the change I submitted Saturday morning had acu number messed up. That is why I am resubmitting.
