### PR TITLE
acu91123 fix for RightScale::Serializer.order_serializers raising exception running in ruby 1.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_agent (0.15.1)
+    right_agent (0.15.2)
       eventmachine (>= 0.12.10, < 2.0)
       json (~> 1.4)
       msgpack (>= 0.4.4, < 0.6)

--- a/lib/right_agent/serialize/serializer.rb
+++ b/lib/right_agent/serialize/serializer.rb
@@ -142,7 +142,13 @@ module RightScale
     # === Return
     # (Array):: Ordered serializers
     def order_serializers(packet)
-      packet.getbyte(0) > 127 ? MSGPACK_FIRST_SERIALIZERS : JSON_FIRST_SERIALIZERS
+      # note the following code for getting the ascii value of the first byte is
+      # efficient for a large packet because it returns an enumerator for the
+      # internal byte array. it is actually more efficient than extracting the
+      # first character as a string and converting it to bytes.
+      # also, the following line works for both ruby 1.8 and ruby 1.9 since the
+      # definition of the bracket operator has changed.
+      packet.bytes.first > 127 ? MSGPACK_FIRST_SERIALIZERS : JSON_FIRST_SERIALIZERS
     end
 
   end # Serializer

--- a/right_agent.gemspec
+++ b/right_agent.gemspec
@@ -24,7 +24,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_agent'
-  spec.version   = '0.15.1'
+  spec.version   = '0.15.2'
   spec.date      = '2013-05-02'
   spec.authors   = ['Lee Kirchhoff', 'Raphael Simon', 'Tony Spataro']
   spec.email     = 'lee@rightscale.com'


### PR DESCRIPTION
@ryanwilliamson to get latest right_agent working with latest right_link
