### PR TITLE
acu91204 - Enhancements in support of RightNet router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,9 @@
 tags
 .DS_Store
 *.swp
-.rvmrc
-.rvmrc*
-.bundle
 pkg/*
 doc/rdocs/*
 nbproject/*
 .loadpath
 .project
+.ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,9 @@ GIT
 PATH
   remote: .
   specs:
-    right_agent (0.15.2)
+    right_agent (0.16.0)
       eventmachine (>= 0.12.10, < 2.0)
-      json (~> 1.4)
+      json (>= 1.4, <= 1.7.6)
       msgpack (>= 0.4.4, < 0.6)
       net-ssh (~> 2.0)
       right_amqp (~> 0.4)

--- a/lib/right_agent/agent_identity.rb
+++ b/lib/right_agent/agent_identity.rb
@@ -97,13 +97,12 @@ module RightScale
     # (AgentIdentity):: Corresponding agent identity
     #
     # === Raise
-    # (RightScale::Exceptions::Argument):: Serialized agent identity is incorrect
+    # (RightScale::Exceptions::Argument):: Serialized agent identity is invalid
     def self.parse(serialized_id)
-      serialized_id = self.compatible_serialized(serialized_id)
-      prefix, agent_type, token, bid, separator = parts(serialized_id)
-      raise RightScale::Exceptions::Argument, "Invalid agent identity token" unless prefix && agent_type && token && bid
+      prefix, agent_type, token, bid, separator = parts(self.compatible_serialized(serialized_id))
+      raise RightScale::Exceptions::Argument, "Invalid agent identity: #{serialized_id.inspect}" unless prefix && agent_type && token && bid
       base_id = bid.to_i
-      raise RightScale::Exceptions::Argument, "Invalid agent identity token (Base ID)" unless base_id.to_s == bid
+      raise RightScale::Exceptions::Argument, "Invalid agent identity base ID: #{bid ? bid : bid.inspect}" unless base_id.to_s == bid
 
       AgentIdentity.new(prefix, agent_type, base_id, token, separator)
     end

--- a/lib/right_agent/exceptions.rb
+++ b/lib/right_agent/exceptions.rb
@@ -22,9 +22,52 @@
 
 module RightScale
   class Exceptions
-    class Application < RuntimeError; end
+    # Capability not currently supported
+    class NotSupported < Exception; end
+
+    # Internal application error
+    class Application < RuntimeError
+      attr_reader :nested_exception
+      def initialize(message, nested_exception = nil)
+        @nested_exception = nested_exception
+        super(message)
+      end
+    end
+
+    # Invalid command or method argument
     class Argument < RuntimeError; end
+
+    # Agent command IO error
     class IO < RuntimeError; end
+
+    # Agent compute platform error
     class PlatformError < StandardError; end
+
+    # Cannot connect or lost connection to external resource
+    class ConnectivityFailure < RuntimeError
+      attr_reader :nested_exception
+      def initialize(message, nested_exception = nil)
+        @nested_exception = nested_exception
+        super(message)
+      end
+    end
+
+    # Request failed but potentially will succeed if retried
+    class RetryableError < RuntimeError
+      attr_reader :nested_exception
+      def initialize(message, nested_exception = nil)
+        @nested_exception = nested_exception
+        super(message)
+      end
+    end
+
+    # Database query failed
+    class QueryFailure < RuntimeError
+      attr_reader :nested_exception
+      def initialize(message, nested_exception = nil)
+        @nested_exception = nested_exception
+        super(message)
+      end
+    end
   end
 end

--- a/lib/right_agent/scripts/stats_manager.rb
+++ b/lib/right_agent/scripts/stats_manager.rb
@@ -162,7 +162,7 @@ module RightScale
         client = CommandClient.new(listen_port, config_options[:cookie])
         command = {:name => :stats, :reset => options[:reset]}
         begin
-          client.send_command(command, options[:verbose], options[:timeout]) { |r| display(agent_name, r, options) }
+          client.send_command(command, verbose = false, options[:timeout]) { |r| display(agent_name, r, options) }
           res = true
         rescue Exception => e
           msg = "Could not retrieve #{agent_name} agent stats: #{e}"

--- a/lib/right_agent/security/cached_certificate_store_proxy.rb
+++ b/lib/right_agent/security/cached_certificate_store_proxy.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,34 +28,48 @@ module RightScale
     # Initialize cache proxy with given certificate store
     #
     # === Parameters
-    # store(Object):: Certificate store responding to get_recipients and
-    #   get_signer
+    # store(Object):: Certificate store responding to get_signer, get_target,
+    # and get_receiver
     def initialize(store)
       @signer_cache = CertificateCache.new
       @store = store
     end
 
-    # Retrieve recipient certificates
-    # Results are not cached
-    #
-    # === Parameters
-    # packet(RightScale::Packet):: Packet containing recipient identity, ignored
-    #
-    # === Return
-    # (Array):: Recipient certificates
-    def get_recipients(obj)
-      @store.get_recipients(obj)
-    end
-
-    # Check cache for signer certificate
+    # Retrieve signer certificates for use in verifying a signature
+    # Check cache first and cache results
     #
     # === Parameters
     # id(String):: Serialized identity of signer
     #
     # === Return
-    # (Array):: Signer certificates
+    # (Array|Certificate):: Signer certificate(s)
     def get_signer(id)
       @signer_cache.get(id) { @store.get_signer(id) }
+    end
+
+    # Retrieve certificates of target for encryption
+    # Results are not cached
+    #
+    # === Parameters
+    # packet(RightScale::Packet):: Packet containing target identity
+    #
+    # === Return
+    # (Array|Certificate):: Target certificate(s)
+    def get_target(obj)
+      @store.get_target(obj)
+    end
+
+    # Retrieve receiver's certificate and key for decryption
+    # Results are not cached
+    #
+    # === Parameters
+    # id(String|nil):: Optional identifier of source of data for use
+    #   in determining who is the receiver
+    #
+    # === Return
+    # (Array):: Certificate and key
+    def get_receiver(id)
+      @store.get_receiver(id)
     end
 
   end # CachedCertificateStoreProxy

--- a/lib/right_agent/security/encrypted_document.rb
+++ b/lib/right_agent/security/encrypted_document.rb
@@ -33,8 +33,7 @@ module RightScale
     #
     # === Parameters
     # data(String):: Data to be encrypted
-    # certs(Array):: Recipient certificates (certificates corresponding to private
-    #   keys that may be used to decrypt data)
+    # certs(Array|Certificate):: Target recipient certificates used to encrypt data
     # cipher(Cipher):: Cipher used for encryption, AES 256 CBC by default
     def initialize(data, certs, cipher = 'AES-256-CBC')
       cipher = OpenSSL::Cipher::Cipher.new(cipher)

--- a/lib/right_agent/security/static_certificate_store.rb
+++ b/lib/right_agent/security/static_certificate_store.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -22,46 +22,62 @@
 
 module RightScale
 
-  # Simple certificate store, serves a static set of certificates
+  # Simple certificate store that serves a static set of certificates and one key
   class StaticCertificateStore
     
     # Initialize store
     #
     # === Parameters
+    # receiver_cert(Certificate):: Certificate for decrypting serialized data being received
+    # receiver_key(RsaKeyPair):: Key corresponding to specified cert
     # signer_certs(Array|Certificate):: Signer certificate(s) used when loading data to
     #   check the digital signature. The signature associated with the serialized data
     #   needs to match with one of the signer certificates for loading to succeed.
-    # recipients_certs(Array|Certificate):: Recipient certificate(s) used when serializing
+    # target_certs(Array|Certificate):: Target certificate(s) used when serializing
     #   data for encryption. Loading the data can only be done through serializers that
-    #   have been initialized with a certificate that's in the recipient certificates
+    #   have been initialized with a certificate that's in the target certificates
     #   if encryption is enabled.
-    def initialize(signer_certs, recipients_certs)
+    def initialize(receiver_cert, receiver_key, signer_certs, target_certs)
+      @receiver_cert = receiver_cert
+      @receiver_key = receiver_key
       signer_certs = [ signer_certs ] unless signer_certs.respond_to?(:each)
       @signer_certs = signer_certs 
-      recipients_certs = [ recipients_certs ] unless recipients_certs.respond_to?(:each)
-      @recipients_certs = recipients_certs
+      target_certs = [ target_certs ] unless target_certs.respond_to?(:each)
+      @target_certs = target_certs
     end
     
-    # Retrieve signer certificates
+    # Retrieve signer certificates for use in verifying a signature
     #
     # === Parameters
     # id(String):: Serialized identity of signer, ignored
     #
     # === Return
-    # (Array):: Signer certificates
+    # (Array|Certificate):: Signer certificates
     def get_signer(id)
       @signer_certs
     end
 
-    # Retrieve recipient certificates that will be able to decrypt the serialized data
+    # Retrieve certificates of target for encryption
     #
     # === Parameters
-    # packet(RightScale::Packet):: Packet containing recipient identity, ignored
+    # packet(RightScale::Packet):: Packet containing target identity, ignored
     #
     # === Return
-    # (Array):: Recipient certificates
-    def get_recipients(packet)
-      @recipients_certs
+    # (Array|Certificate):: Target certificates
+    def get_target(packet)
+      @target_certs
+    end
+
+    # Retrieve receiver's certificate and key for decryption
+    #
+    # === Parameters
+    # id(String|nil):: Optional identifier of source of data for use
+    #   in determining who is the receiver, ignored
+    #
+    # === Return
+    # (Array):: Certificate and key
+    def get_receiver(id)
+      [@receiver_cert, @receiver_key]
     end
     
   end # StaticCertificateStore

--- a/lib/right_agent/sender.rb
+++ b/lib/right_agent/sender.rb
@@ -808,7 +808,7 @@ module RightScale
       build_and_send_packet(:send_persistent_request, type, payload, target, callback)
     end
 
-    # Build packet
+    # Build packet or queue it if offline
     #
     # === Parameters
     # kind(Symbol):: Kind of send request: :send_push, :send_persistent_push, :send_retryable_request,
@@ -825,30 +825,69 @@ module RightScale
     # callback(Boolean):: Whether this request has an associated response callback
     #
     # === Return
-    # (Push|Request):: Packet created
+    # (Push|Request|NilClass):: Packet created, or nil if queued instead
+    #
+    # === Raise
+    # ArgumentError:: If target is invalid
     def build_packet(kind, type, payload, target, callback = false)
-      kind_str = kind.to_s
-      persistent = !!(kind_str =~ /persistent/)
-      if kind_str =~ /push/
-        packet = Push.new(type, payload)
-        packet.selector = target[:selector] || :any if target.is_a?(Hash)
-        packet.confirm = true if callback
+      validate_target(target, !!(kind.to_s =~ /push/))
+      if should_queue?
+        @offline_handler.queue_request(kind, type, payload, target, callback)
+        nil
       else
-        packet = Request.new(type, payload)
-        ttl = @options[:time_to_live]
-        packet.expires_at = Time.now.to_i + ttl if !persistent && ttl && ttl != 0
-        packet.selector = :any
+        kind_str = kind.to_s
+        persistent = !!(kind_str =~ /persistent/)
+        if kind_str =~ /push/
+          packet = Push.new(type, payload)
+          packet.selector = target[:selector] || :any if target.is_a?(Hash)
+          packet.confirm = true if callback
+        else
+          packet = Request.new(type, payload)
+          ttl = @options[:time_to_live]
+          packet.expires_at = Time.now.to_i + ttl if !persistent && ttl && ttl != 0
+          packet.selector = :any
+        end
+        packet.from = @identity
+        packet.token = AgentIdentity.generate
+        packet.persistent = persistent
+        if target.is_a?(Hash)
+          packet.tags = target[:tags] || []
+          packet.scope = target[:scope]
+        else
+          packet.target = target
+        end
+        packet
       end
-      packet.from = @identity
-      packet.token = AgentIdentity.generate
-      packet.persistent = persistent
-      if target.is_a?(Hash)
-        packet.tags = target[:tags] || []
-        packet.scope = target[:scope]
-      else
-        packet.target = target
+    end
+
+    # Send packet
+    #
+    # === Parameters
+    # kind(Symbol):: Kind of send request: :send_push, :send_persistent_push, :send_retryable_request,
+    #   or :send_persistent_request
+    # packet(Push|Request|NilClass):: Packet to send; nothing sent if nil
+    # callback(Proc|nil):: Block used to process routing response
+    #
+    # === Return
+    # true:: Always return true
+    #
+    # === Raise
+    # SendFailure:: If publishing of request fails unexpectedly
+    # TemporarilyOffline:: If cannot publish request because currently not connected
+    #    to any brokers and offline queueing is disabled
+    def send_packet(kind, packet, callback)
+      if packet
+        method = packet.type.split('/').last
+        received_at = @request_stats.update(method, packet.token)
+        @request_kind_stats.update((packet.selector == :all ? kind.to_s.sub(/push/, "fanout") : kind.to_s)[5..-1])
+        @pending_requests[packet.token] = PendingRequest.new(kind, received_at, callback) if callback
+        if !packet.persistent && kind.to_s =~ /request/
+          publish_with_timeout_retry(packet, packet.token)
+        else
+          publish(packet)
+        end
       end
-      packet
+      true
     end
 
     # Handle response to a request
@@ -1085,21 +1124,8 @@ module RightScale
     # TemporarilyOffline:: If cannot publish request because currently not connected
     #    to any brokers and offline queueing is disabled
     def build_and_send_packet(kind, type, payload, target, callback)
-      validate_target(target, allow_selector = !!(kind.to_s =~ /push/))
-      if should_queue?
-        @offline_handler.queue_request(kind, type, payload, target, callback)
-      else
-        packet = build_packet(kind, type, payload, target, callback)
-        method = type.split('/').last
-        received_at = @request_stats.update(method, packet.token)
-        @request_kind_stats.update((packet.selector == :all ? kind.to_s.sub(/push/, "fanout") : kind.to_s)[5..-1])
-        @pending_requests[packet.token] = PendingRequest.new(kind, received_at, callback) if callback
-        if !packet.persistent && kind.to_s =~ /request/
-          publish_with_timeout_retry(packet, packet.token)
-        else
-          publish(packet)
-        end
-      end
+      packet = build_packet(kind, type, payload, target, callback)
+      send_packet(kind, packet, callback)
       true
     end
 
@@ -1178,7 +1204,7 @@ module RightScale
                 @non_delivery_stats.update(result.content)
                 handle_response(Result.new(request.token, request.reply_to, result, @identity))
               end
-              @connectivity_checker.check(published_broker_ids.first) if count == 1
+              @connectivity_checker.check(published_broker_ids.first) if count == 1 && !published_broker_ids.empty?
             end
           rescue TemporarilyOffline => e
             # Send retry response so that requester, e.g., IdempotentRequest, can retry

--- a/lib/right_agent/serialize/secure_serializer_initializer.rb
+++ b/lib/right_agent/serialize/secure_serializer_initializer.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -37,8 +37,8 @@ module RightScale
       cert = Certificate.load(AgentConfig.certs_file("#{agent_type}.cert"))
       key = RsaKeyPair.load(AgentConfig.certs_file("#{agent_type}.key"))
       mapper_cert = Certificate.load(AgentConfig.certs_file("mapper.cert"))
-      store = StaticCertificateStore.new(mapper_cert, mapper_cert)
-      SecureSerializer.init(Serializer.new, agent_id, cert, key, store)
+      store = StaticCertificateStore.new(cert, key, mapper_cert, mapper_cert)
+      SecureSerializer.init(Serializer.new, agent_id, store)
       true
     end
 

--- a/right_agent.gemspec
+++ b/right_agent.gemspec
@@ -24,8 +24,8 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_agent'
-  spec.version   = '0.15.2'
-  spec.date      = '2013-05-02'
+  spec.version   = '0.16.0'
+  spec.date      = '2013-05-28'
   spec.authors   = ['Lee Kirchhoff', 'Raphael Simon', 'Tony Spataro']
   spec.email     = 'lee@rightscale.com'
   spec.homepage  = 'https://github.com/rightscale/right_agent'
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('right_support', ['>= 2.4.1', '< 3.0'])
   spec.add_dependency('right_amqp', '~> 0.4')
-  spec.add_dependency('json', ['~> 1.4'])
+  spec.add_dependency('json', ['>= 1.4', '<= 1.7.6']) # json_create behavior change in 1.7.7
   spec.add_dependency('eventmachine', ['>= 0.12.10', '< 2.0'])
   spec.add_dependency('msgpack', ['>= 0.4.4', '< 0.6'])
   spec.add_dependency('net-ssh', '~> 2.0')

--- a/right_agent.rconf
+++ b/right_agent.rconf
@@ -1,9 +1,8 @@
 ruby do
-  version  'ruby-1.9.2-p180'
-  rubygems '1.8.11'
+  version  'ruby-1.9.2-p290'
   gemset   'right_agent'
 end
 bundler do
-  version     '1.2.1'
+  version     '1.1.4'
   bundle_path File.join(ENV["HOME"], '.rightscale', 'right_agent')
 end

--- a/spec/security/cached_certificate_store_proxy_spec.rb
+++ b/spec/security/cached_certificate_store_proxy_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -27,30 +27,36 @@ describe RightScale::CachedCertificateStoreProxy do
   include RightScale::SpecHelper
 
   before(:all) do
+    @cert, @key = issue_cert
     @signer, key = issue_cert
-    @recipient, key = issue_cert
+    @target, key = issue_cert
     @store = flexmock("Store")
     @proxy = RightScale::CachedCertificateStoreProxy.new(@store)
   end
 
   it 'should not raise and return nil for non existent certificates' do
     res = nil
-    @store.should_receive(:get_recipients).with(nil).and_return(nil)
-    lambda { res = @proxy.get_recipients(nil) }.should_not raise_error
+    @store.should_receive(:get_target).with(nil).and_return(nil)
+    lambda { res = @proxy.get_target(nil) }.should_not raise_error
     res.should == nil
     @store.should_receive(:get_signer).with(nil).and_return(nil)
     lambda { res = @proxy.get_signer(nil) }.should_not raise_error
     res.should == nil
   end
 
-  it 'should return recipient certificates' do
-    @store.should_receive(:get_recipients).with('anything').and_return(@recipient)
-    @proxy.get_recipients('anything').should == @recipient
+  it 'should return target certificates' do
+    @store.should_receive(:get_target).with('anything').and_return(@target)
+    @proxy.get_target('anything').should == @target
   end
   
   it 'should return signer certificates' do
     @store.should_receive(:get_signer).with('anything').and_return(@signer)
     @proxy.get_signer('anything').should == @signer
   end
-  
+
+  it 'should return receiver certificate and key' do
+    @store.should_receive(:get_receiver).with('anything').and_return([@cert, @key])
+    @proxy.get_receiver('anything').should == [@cert, @key]
+  end
+
 end

--- a/spec/security/static_certificate_store_spec.rb
+++ b/spec/security/static_certificate_store_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -28,25 +28,31 @@ describe RightScale::StaticCertificateStore do
 
   before(:all) do
     @signer, key = issue_cert
-    @recipient, key = issue_cert
+    @target, key = issue_cert
     @cert, @key = issue_cert
-    @store = RightScale::StaticCertificateStore.new(@signer, @recipient)
+    @store = RightScale::StaticCertificateStore.new(@cert, @key, @signer, @target)
   end
 
   it 'should not raise when passed nil objects' do
     res = nil
     lambda { res = @store.get_signer(nil) }.should_not raise_error
     res.should == [ @signer ]
-    lambda { res = @store.get_recipients(nil) }.should_not raise_error
-    res.should == [ @recipient ]
+    lambda { res = @store.get_target(nil) }.should_not raise_error
+    res.should == [ @target ]
+    lambda { res = @store.get_receiver(nil) }.should_not raise_error
+    res.should == [ @cert, @key ]
   end
 
   it 'should return signer certificates' do
     @store.get_signer('anything').should == [ @signer ]
   end
 
-  it 'should return recipient certificates' do
-    @store.get_recipients('anything').should == [ @recipient ]
+  it 'should return target certificates' do
+    @store.get_target('anything').should == [ @target ]
+  end
+
+  it 'should return certificate and key for decrypting' do
+    @store.get_receiver('anything').should == [ @cert, @key ]
   end
   
 end

--- a/spec/serialize/secure_serializer_spec.rb
+++ b/spec/serialize/secure_serializer_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -38,65 +38,94 @@ describe RightScale::SecureSerializer do
   include RightScale::SpecHelper
 
   before(:all) do
-    @certificate, @key = issue_cert
-    @store = RightScale::StaticCertificateStore.new(@certificate, @certificate)
-    @identity = "id"
+    @dump_cert, @dump_key = issue_cert
+    @load_cert, @load_key = issue_cert
+    @dump_store = RightScale::StaticCertificateStore.new(@dump_cert, @dump_key, @load_cert, @load_cert)
+    @load_store = RightScale::StaticCertificateStore.new(@load_cert, @load_key, @dump_cert, @dump_cert)
+    @dump_id = RightScale::AgentIdentity.new("rs", "dump_agent", 1).to_s
+    @load_id = RightScale::AgentIdentity.new("rs", "load_agent", 1).to_s
   end
 
-  it 'should raise when not initialized' do
-    data = RightScale::Result.new("token", "to", "from", ["results"])
-    lambda { RightScale::SecureSerializer.dump(data) }.should raise_error
+  it "must be initialized before use" do
+    data = RightScale::Result.new("token", "to", ["results"], "from")
+    lambda { RightScale::SecureSerializer.dump(data) }.should raise_error(Exception, "Secure serializer not initialized")
   end
 
-  it 'should raise when data not serialized with MessagePack or JSON' do
-    data = RightScale::Result.new("token", "to", "from", ["results"])
-    RightScale::SecureSerializer.init(RightScale::Serializer.new, @identity, @certificate, @key, @store, false)
+  it "must specify agent identity" do
+    lambda { RightScale::SecureSerializer.init(RightScale::Serializer.new, nil, @load_store, false) }.
+        should raise_error(Exception, "Missing local agent identity")
+  end
+
+  it "must specify a credentials store" do
+    lambda { RightScale::SecureSerializer.init(RightScale::Serializer.new, @load_id, nil, false) }.
+        should raise_error(Exception, "Missing credentials store")
+  end
+
+  it "certificate store must contain certificate and key for agent" do
+    flexmock(@load_store).should_receive(:get_receiver).and_return([nil, nil]).once
+    lambda { RightScale::SecureSerializer.init(RightScale::Serializer.new, @load_id, @load_store, false) }.
+        should raise_error(Exception, "Missing local agent public certificate")
+  end
+
+  it "data must be serialized with MessagePack or JSON" do
+    data = RightScale::Result.new("token", "to", ["results"], "from")
+    RightScale::SecureSerializer.init(RightScale::Serializer.new, @load_id, @load_store, false)
     lambda { RightScale::SecureSerializer.load(Marshal.dump(data)) }.should raise_error(RightScale::Serializer::SerializationError)
     lambda { RightScale::SecureSerializer.load(YAML.dump(data)) }.should raise_error(RightScale::Serializer::SerializationError)
   end
 
-  describe "using MessagePack" do
+  # Test with protocol version 11 and 12 since that is the boundary where msgpack was first supported
+  [[:msgpack, 12, JSON], [:json, 11, MessagePack]].each do |type, version, other_class|
 
-    before(:each) do
-      flexmock(JSON).should_receive(:dump).never
-      flexmock(JSON).should_receive(:load).never
-      @data = RightScale::Result.new("token", "to", "from", ["results"], nil, nil, nil, nil, [12, 12])
+    context "using #{type.inspect}" do
+
+      before(:each) do
+        flexmock(other_class).should_receive(:dump).never
+        flexmock(other_class).should_receive(:load).never
+        @data = RightScale::Result.new("token", "to", ["results"], "from", nil, nil, nil, nil, [version, version])
+        @serializer = RightScale::Serializer.new(type)
+      end
+
+      it "unserializes signed data" do
+        RightScale::SecureSerializer.init(@serializer, @dump_id, @dump_store, false)
+        data = RightScale::SecureSerializer.dump(@data)
+        RightScale::SecureSerializer.init(@serializer, @load_id, @load_store, false)
+        RightScale::SecureSerializer.load(data).should == @data
+      end
+
+      it "unserializes encrypted data" do
+        RightScale::SecureSerializer.init(@serializer, @dump_id, @dump_store, true)
+        data = RightScale::SecureSerializer.dump(@data)
+        @serializer.load(data)["encrypted"].should be_true
+        RightScale::SecureSerializer.init(@serializer, @load_id, @load_store, false)
+        RightScale::SecureSerializer.load(data).should == @data
+      end
+
+      it "encrypt option on initialization overrides dump option" do
+        RightScale::SecureSerializer.init(@serializer, @dump_id, @dump_store, true)
+        data = RightScale::SecureSerializer.dump(@data, false)
+        @serializer.load(data)["encrypted"].should be_true
+      end
+
+      it "uses id when supplied to choose credentials" do
+        RightScale::SecureSerializer.init(@serializer, @dump_id, @dump_store, true)
+        data = RightScale::SecureSerializer.dump(@data)
+        RightScale::SecureSerializer.init(@serializer, @load_id, @load_store, false)
+        flexmock(@load_store).should_receive(:get_receiver).with("id").and_return([@load_cert, @load_key]).once
+        RightScale::SecureSerializer.load(data, "id").should == @data
+      end
+
+      it "must be able to retrieve certificate and key to decrypt message" do
+        RightScale::SecureSerializer.init(@serializer, @dump_id, @dump_store, true)
+        data = RightScale::SecureSerializer.dump(@data)
+        RightScale::SecureSerializer.init(@serializer, @dump_id, @load_store, false)
+        flexmock(@load_store).should_receive(:get_receiver).with("id").and_return([nil, @load_key], [@load_cert, nil]).twice
+        lambda { RightScale::SecureSerializer.load(data, "id") }.
+            should raise_error(RightScale::SecureSerializer::MissingCertificate, /Could not find a certificate/)
+        lambda { RightScale::SecureSerializer.load(data, "id") }.
+            should raise_error(RightScale::SecureSerializer::MissingPrivateKey, /Could not find a private key/)
+      end
     end
-
-    it 'should unserialize signed data' do
-      RightScale::SecureSerializer.init(RightScale::Serializer.new, @identity, @certificate, @key, @store, false)
-      data = RightScale::SecureSerializer.dump(@data)
-      RightScale::SecureSerializer.load(data).should == @data
-    end
-
-    it 'should unserialize encrypted data' do
-      RightScale::SecureSerializer.init(RightScale::Serializer.new, @identity, @certificate, @key, @store, true)
-      data = RightScale::SecureSerializer.dump(@data)
-      RightScale::SecureSerializer.load(data).should == @data
-    end
-
-  end
-
-  describe "using JSON" do
-
-    before(:each) do
-      flexmock(MessagePack).should_receive(:dump).never
-      flexmock(MessagePack).should_receive(:load).never
-      @data = RightScale::Result.new("token", "to", "from", ["results"], nil, nil, nil, nil, [11, 11])
-    end
-
-    it 'should unserialize signed data' do
-      RightScale::SecureSerializer.init(RightScale::Serializer.new, @identity, @certificate, @key, @store, false)
-      data = RightScale::SecureSerializer.dump(@data)
-      RightScale::SecureSerializer.load(data).should == @data
-    end
-
-    it 'should unserialize encrypted data' do
-      RightScale::SecureSerializer.init(RightScale::Serializer.new, @identity, @certificate, @key, @store, true)
-      data = RightScale::SecureSerializer.dump(@data)
-      RightScale::SecureSerializer.load(data).should == @data
-    end
-
   end
 
 end

--- a/spec/serialize/serializer_spec.rb
+++ b/spec/serialize/serializer_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2011 RightScale Inc
+# Copyright (c) 2009-2013 RightScale Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -133,7 +133,7 @@ describe RightScale::Serializer do
 
     it "should cascade through available serializers" do
       serializer = RightScale::Serializer.new
-      flexmock(serializer).should_receive(:cascade_serializers).with(:load, "olleh", [JSON, MessagePack]).once
+      flexmock(serializer).should_receive(:cascade_serializers).with(:load, "olleh", [JSON, MessagePack], nil).once
       serializer.load("olleh")
     end
 
@@ -157,6 +157,13 @@ describe RightScale::Serializer do
       flexmock(JSON).should_receive(:load).with(serialized).never
       flexmock(MessagePack).should_receive(:load).with(serialized).and_return(object).once
       RightScale::Serializer.new(:json).load(serialized)
+    end
+
+    it "should pass along optional id to serializer" do
+      object = [1, 2, 3]
+      serialized = object.to_msgpack
+      flexmock(MessagePack).should_receive(:load).with(serialized, "id").and_return(object).once
+      RightScale::Serializer.new.load(serialized, "id")
     end
 
     it "should raise SerializationError if packet could not be unserialized" do


### PR DESCRIPTION
acu58878 - Refactor dispatching to allow for multiple dispatchers

acu58878 - Allow Sender user to build and send packet on own

acu58878 - Add ConnectivityFailure and RetyrableError exceptions

acu58878 - Limit JSON version to 1.7.6 to avoid json_create behavior change

acu58878 - Update rconf config for 1.0 version

acu58878 - Add QueryFailure exception

acu58878 - Make clearer why agent identity is invalid

acu58878 - In Sender only ping mapper if publish returns ids

acu58878 - Fix use of history to deal with early terminate

acu58878 - Extend SecureSerializer to accept additional cues as to how to decrypt a message

@ryanwilliamson @tony-spataro-rs @raphael 
