### PR TITLE
teal_13_18_acu139248_bump_agent_protocol_version_for_RL6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_agent (0.17.2)
+    right_agent (0.17.3)
       eventmachine (>= 0.12.10, < 2.0)
       json (>= 1.4, <= 1.7.6)
       msgpack (>= 0.4.4, < 0.6)

--- a/VERSION
+++ b/VERSION
@@ -49,3 +49,4 @@
 # 19: Allow array of targets for Push or Request
 # 20: Add CANCEL status to OperationResult
 # 21: Infrastructure agents gained HTTP transport in lieu of AMQP. Bumped version to distinguish RightLink v5.9 from v5.8 due to app-level behavioral differences.
+# 22: Bumped version to distinguish RightLink v6.0 from v5.9 due to app-level behavioral differences.

--- a/lib/right_agent/agent_config.rb
+++ b/lib/right_agent/agent_config.rb
@@ -63,7 +63,7 @@ module RightScale
   module AgentConfig
 
     # Current agent protocol version
-    PROTOCOL_VERSION = 21
+    PROTOCOL_VERSION = 22
 
     # Current agent protocol version
     #

--- a/right_agent.gemspec
+++ b/right_agent.gemspec
@@ -24,8 +24,8 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_agent'
-  spec.version   = '0.17.2'
-  spec.date      = '2013-10-28'
+  spec.version   = '0.17.3'
+  spec.date      = '2013-11-21'
   spec.authors   = ['Lee Kirchhoff', 'Raphael Simon', 'Tony Spataro']
   spec.email     = 'lee@rightscale.com'
   spec.homepage  = 'https://github.com/rightscale/right_agent'


### PR DESCRIPTION
@robertsulway bump agent protocol version so that RightLink 6.0 can test against release4.11
