### PR TITLE
 teal_13_17_acu134044_support_mingw

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_agent (1.0.2)
+    right_agent (1.0.3)
       eventmachine (>= 0.12.10, < 2.0)
       ffi
       json (~> 1.4)

--- a/right_agent.gemspec
+++ b/right_agent.gemspec
@@ -1,5 +1,5 @@
 # -*-ruby-*-
-# Copyright: Copyright (c) 2011 RightScale, Inc.
+# Copyright: Copyright (c) 2011-2013 RightScale, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,11 +21,12 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'rubygems'
+require 'rbconfig'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_agent'
-  spec.version   = '1.0.2'
-  spec.date      = '2013-11-21'
+  spec.version   = '1.0.3'
+  spec.date      = '2013-11-22'
   spec.authors   = ['Lee Kirchhoff', 'Raphael Simon', 'Tony Spataro', 'Scott Messier']
   spec.email     = 'lee@rightscale.com'
   spec.homepage  = 'https://github.com/rightscale/right_agent'
@@ -42,17 +43,41 @@ Gem::Specification.new do |spec|
   spec.add_dependency('eventmachine', ['>= 0.12.10', '< 2.0'])
   spec.add_dependency('net-ssh', '~> 2.0')
 
-  # not currently needed by Linux but it does no harm to have it.
-  spec.add_dependency('ffi')
-  case RUBY_PLATFORM
-  when /mswin|mingw/i
-    spec.add_dependency('win32-dir', '~> 0.4.5')
-    spec.add_dependency('win32-process', '~> 0.7.3')
-  when /win32|dos|cygwin/i
+  # TEAL HACK: rake gem may override current RUBY_PLATFORM to allow building
+  # gems for all supported platforms from any platform. rubygems 1.8.x makes it
+  # necessary to produce platform-specific gems with context-sensitive gemspecs
+  # in order to retain Windows (or Linux)-specific gem requirements. this works
+  # from any platform because there is no native code to pre-compile and package
+  # with this gem.
+  gem_platform = defined?(::RightScale::MultiPlatformGemTask.gem_platform_override) ?
+    ::RightScale::MultiPlatformGemTask.gem_platform_override :
+    nil
+  gem_platform ||= ::RbConfig::CONFIG['host_os']
+  case gem_platform
+  when /mswin/i
+    spec.add_dependency('win32-api', ['>= 1.4.5', '< 1.4.7'])
+    spec.add_dependency('win32-dir', '~> 0.3.5')
+    spec.add_dependency('win32-process', '~> 0.6.1')
+    spec.add_dependency('msgpack', ['>= 0.4.4', '< 0.5'])
+    spec.add_dependency('json', '1.4.6')
+    spec.platform = 'x86-mswin32-60'
+  when /mingw/i
+    spec.add_dependency('ffi')
+    spec.add_dependency('win32-dir', '>= 0.3.5')
+    spec.add_dependency('win32-process', '>= 0.6.1')
+    spec.add_dependency('msgpack', ['>= 0.4.4', '< 0.6'])
+    spec.add_dependency('json', '~> 1.4')
+    spec.platform = 'x86-mingw32'
+  when /win32|dos|cygwin|windows/i
     raise ::NotImplementedError, 'Unsupported Ruby-on-Windows variant'
+  else
+    # ffi is not currently needed by Linux but it does no harm to have it and it
+    # allows bundler to generate a consistent Gemfile.lock when it is declared
+    # for both mingw and Linux.
+    spec.add_dependency('ffi')
+    spec.add_dependency('msgpack', ['>= 0.4.4', '< 0.6'])
+    spec.add_dependency('json', '~> 1.4')
   end
-  spec.add_dependency('msgpack', ['>= 0.4.4', '< 0.6'])
-  spec.add_dependency('json', '~> 1.4')
 
   spec.description = <<-EOF
 RightAgent provides a foundation for running an agent on a server to interface


### PR DESCRIPTION
@szmyd added logic to Rakefile and gemspec such that rake gem will generate two .gem files in the pkg directory; one for Linux and one for mingw.
this works regardless of the current platform (i.e. works the same on Windows or Linux).
this is necessary because rubygems 1.8.x by default will only produce a .gem with a gemspec that lists gem dependencies for the current platform even if logic in the gemspec would indicate different gem dependencies for other platforms.
