### PR TITLE
Changes to dependencies for Rails 3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source 'http://gems.test.rightscale.com'
 source 'https://rubygems.org'
 
 gemspec
@@ -13,7 +12,8 @@ gem 'json', '~> 1.4'
 
 # Lock eventmachine to a published and well-tested version to avoid picking up
 # proprietary builds that happen to be installed locally
-gem 'eventmachine', '~> 1.0.0.10'
+gem 'eventmachine', '~> 1.0.0.10', git: 'git@github.com:rightscale/rightscale-eventmachine.git'
+gem 'rest-client', git: 'git@github.com:flexera-public/rest-client.git', ref: '4df6b644cd495be4da6f16a3d1ca7de420a7d90e'
 gem 'airbrake-ruby', '~> 1.2'
 
 # we test with Ruby 2.0 which is not compatible with Rack 2.x

--- a/right_agent.gemspec
+++ b/right_agent.gemspec
@@ -25,7 +25,7 @@ require 'rbconfig'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_agent'
-  spec.version   = '2.7.2'
+  spec.version   = '2.8.0-rc.1'
   spec.date      = '2016-07-25'
   spec.authors   = ['Lee Kirchhoff', 'Raphael Simon', 'Tony Spataro', 'Scott Messier']
   spec.email     = 'lee@rightscale.com'
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rest-client', '~> 1.7.0.3')
   spec.add_dependency('faye-websocket', '~> 0.7.0')
   spec.add_dependency('eventmachine', ['>= 0.12.10', '< 2.0'])
-  spec.add_dependency('net-ssh', '~> 2.0')
+  spec.add_dependency('net-ssh', '>= 2.6.5')
   spec.add_dependency('addressable', '~> 2.3')
 
   # TEAL HACK: rake gem may override current RUBY_PLATFORM to allow building


### PR DESCRIPTION
Removes the reliance on http://gems.test.rightscale.com and changes the net-ssh dependency to allow for usage in Rails 3 projects